### PR TITLE
feat(frontend): BikeLocationPicker, form enums, BikeMarker cleanup, fix rentals after reload

### DIFF
--- a/frontend/src/features/Bikes/components/BikeForm.tsx
+++ b/frontend/src/features/Bikes/components/BikeForm.tsx
@@ -1,7 +1,12 @@
 import { useState } from "react";
 import type { FormEvent } from "react";
 import type { BikePayload } from "../types";
+import { BIKE_STATE_OPTIONS, BIKE_TYPE_OPTIONS } from "../types";
 import type { ApiError } from "../../../types";
+import BikeLocationPicker from "./BikeLocationPicker";
+
+const DEFAULT_LAT = 6.244;
+const DEFAULT_LNG = -75.5812;
 
 interface BikeFormProps {
   defaultValues?: Partial<BikePayload>;
@@ -17,21 +22,43 @@ export default function BikeForm({
   error,
 }: BikeFormProps) {
   const [brand, setBrand] = useState(defaultValues?.brand ?? "");
-  const [type, setType] = useState(defaultValues?.type ?? "");
+  const initialType =
+    defaultValues?.type &&
+    BIKE_TYPE_OPTIONS.includes(defaultValues.type as (typeof BIKE_TYPE_OPTIONS)[number])
+      ? defaultValues.type
+      : "";
+  const [type, setType] = useState(initialType);
   const [colour, setColour] = useState(defaultValues?.colour ?? "");
   const [latitude, setLatitude] = useState(
-    defaultValues?.latitude?.toString() ?? "",
+    () =>
+      defaultValues?.latitude != null
+        ? String(defaultValues.latitude)
+        : String(DEFAULT_LAT),
   );
   const [longitude, setLongitude] = useState(
-    defaultValues?.longitude?.toString() ?? "",
+    () =>
+      defaultValues?.longitude != null
+        ? String(defaultValues.longitude)
+        : String(DEFAULT_LNG),
   );
-  const [state, setStatus] = useState(defaultValues?.state ?? "");
+
+  function setPositionFromMap(lat: number, lng: number) {
+    setLatitude(lat.toFixed(6));
+    setLongitude(lng.toFixed(6));
+  }
+  const initialStateRaw = defaultValues?.state ?? "Free";
+  const initialState = BIKE_STATE_OPTIONS.includes(
+    initialStateRaw as (typeof BIKE_STATE_OPTIONS)[number],
+  )
+    ? initialStateRaw
+    : "Free";
+  const [state, setStatus] = useState(initialState);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   function validate(): boolean {
     const errors: Record<string, string> = {};
     if (!brand.trim()) errors.brand = "Brand is required";
-    if (!type.trim()) errors.type = "Type is required";
+    if (!type.trim()) errors.type = "Select a bike type";
     if (!colour.trim()) errors.colour = "Colour is required";
     if (!latitude.trim()) {
       errors.latitude = "Latitude is required";
@@ -65,7 +92,7 @@ export default function BikeForm({
       latitude: Number(latitude),
       longitude: Number(longitude),
     };
-    if (state.trim()) payload.state = state.trim();
+    payload.state = state;
     onSubmit(payload);
   }
 
@@ -81,7 +108,7 @@ export default function BikeForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className="flex flex-col gap-4 w-full max-w-lg text-left"
+      className="flex flex-col gap-4 w-full max-w-2xl text-left"
     >
       {error && error.error !== "VALIDATION_ERROR" && (
         <div className="text-danger-400 text-sm p-2 border border-danger-400 rounded">
@@ -106,12 +133,18 @@ export default function BikeForm({
 
       <label>
         <div className="text-sm font-medium text-text mb-1">Type *</div>
-        <input
-          type="text"
+        <select
           value={type}
           onChange={(e) => setType(e.target.value)}
-          className="w-full px-3 py-2 border border-border rounded focus:outline-none focus:border-brand-300"
-        />
+          className="w-full px-3 py-2 border border-border rounded focus:outline-none focus:border-brand-300 bg-surface text-text"
+        >
+          <option value="">Select type…</option>
+          {BIKE_TYPE_OPTIONS.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
         {(fieldErrors.type || getApiFieldError("type")) && (
           <div className="text-danger-400 text-xs mt-1">
             {fieldErrors.type || getApiFieldError("type")}
@@ -134,47 +167,35 @@ export default function BikeForm({
         )}
       </label>
 
-      <label>
-        <div className="text-sm font-medium text-text mb-1">Latitude *</div>
-        <input
-          type="number"
-          step="any"
-          value={latitude}
-          onChange={(e) => setLatitude(e.target.value)}
-          className="w-full px-3 py-2 border border-border rounded focus:outline-none focus:border-brand-300"
-        />
-        {(fieldErrors.latitude || getApiFieldError("latitude")) && (
-          <div className="text-danger-400 text-xs mt-1">
-            {fieldErrors.latitude || getApiFieldError("latitude")}
-          </div>
-        )}
-      </label>
+      <BikeLocationPicker
+        latitude={latitude}
+        longitude={longitude}
+        onChange={setPositionFromMap}
+      />
+      {(fieldErrors.latitude || getApiFieldError("latitude")) && (
+        <div className="text-danger-400 text-xs -mt-2">
+          {fieldErrors.latitude || getApiFieldError("latitude")}
+        </div>
+      )}
+      {(fieldErrors.longitude || getApiFieldError("longitude")) && (
+        <div className="text-danger-400 text-xs -mt-2">
+          {fieldErrors.longitude || getApiFieldError("longitude")}
+        </div>
+      )}
 
       <label>
-        <div className="text-sm font-medium text-text mb-1">Longitude *</div>
-        <input
-          type="number"
-          step="any"
-          value={longitude}
-          onChange={(e) => setLongitude(e.target.value)}
-          className="w-full px-3 py-2 border border-border rounded focus:outline-none focus:border-brand-300"
-        />
-        {(fieldErrors.longitude || getApiFieldError("longitude")) && (
-          <div className="text-danger-400 text-xs mt-1">
-            {fieldErrors.longitude || getApiFieldError("longitude")}
-          </div>
-        )}
-      </label>
-
-      <label>
-        <div className="text-sm font-medium text-text mb-1">Status</div>
-        <input
-          type="text"
+        <div className="text-sm font-medium text-text mb-1">Status *</div>
+        <select
           value={state}
           onChange={(e) => setStatus(e.target.value)}
-          placeholder="e.g. Free, Rented"
-          className="w-full px-3 py-2 border border-border rounded focus:outline-none focus:border-brand-300"
-        />
+          className="w-full px-3 py-2 border border-border rounded focus:outline-none focus:border-brand-300 bg-surface text-text"
+        >
+          {BIKE_STATE_OPTIONS.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
       </label>
 
       <button

--- a/frontend/src/features/Bikes/components/BikeLocationPicker.tsx
+++ b/frontend/src/features/Bikes/components/BikeLocationPicker.tsx
@@ -1,0 +1,105 @@
+import L from "leaflet";
+import markerIcon from "leaflet/dist/images/marker-icon.png";
+import markerShadow from "leaflet/dist/images/marker-shadow.png";
+import {
+  MapContainer,
+  Marker,
+  TileLayer,
+  ZoomControl,
+  useMapEvents,
+} from "react-leaflet";
+
+const DefaultIcon = L.icon({
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
+L.Marker.prototype.options.icon = DefaultIcon;
+
+const DEFAULT_LAT = 6.244;
+const DEFAULT_LNG = -75.5812;
+
+function MapClickHandler({
+  onPosition,
+}: {
+  onPosition: (lat: number, lng: number) => void;
+}) {
+  useMapEvents({
+    click(e) {
+      onPosition(e.latlng.lat, e.latlng.lng);
+    },
+  });
+  return null;
+}
+
+interface BikeLocationPickerProps {
+  latitude: string;
+  longitude: string;
+  onChange: (lat: number, lng: number) => void;
+}
+
+function parsePosition(latitude: string, longitude: string): [number, number] {
+  const lat = Number(latitude);
+  const lng = Number(longitude);
+  const okLat = Number.isFinite(lat) && lat >= -90 && lat <= 90;
+  const okLng = Number.isFinite(lng) && lng >= -180 && lng <= 180;
+  return [
+    okLat ? lat : DEFAULT_LAT,
+    okLng ? lng : DEFAULT_LNG,
+  ];
+}
+
+export default function BikeLocationPicker({
+  latitude,
+  longitude,
+  onChange,
+}: BikeLocationPickerProps) {
+  const position = parsePosition(latitude, longitude);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-sm font-medium text-text">Location *</div>
+      <p className="text-xs text-text-muted">
+        Click on the map or drag the pin to set latitude and longitude.
+      </p>
+      <div
+        className="rounded border border-border overflow-hidden w-full"
+        style={{ height: 280 }}
+      >
+        <MapContainer
+          center={position}
+          zoom={13}
+          style={{ height: "100%", width: "100%" }}
+          zoomControl={false}
+          scrollWheelZoom
+        >
+          <TileLayer
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          />
+          <ZoomControl position="topright" />
+          <MapClickHandler onPosition={onChange} />
+          <Marker
+            position={position}
+            draggable
+            eventHandlers={{
+              dragend(e) {
+                const p = e.target.getLatLng();
+                onChange(p.lat, p.lng);
+              },
+            }}
+          />
+        </MapContainer>
+      </div>
+      <p className="text-xs text-text-muted font-mono">
+        {Number.isFinite(Number(latitude)) && Number.isFinite(Number(longitude))
+          ? `${Number(latitude).toFixed(6)}, ${Number(longitude).toFixed(6)}`
+          : "—"}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/features/Bikes/types/index.ts
+++ b/frontend/src/features/Bikes/types/index.ts
@@ -1,8 +1,17 @@
+/** Coinciden con `BikeType` / `BikeState` en el MS bikes */
+export const BIKE_TYPE_OPTIONS = ["Cross", "Mountain", "Street"] as const;
+export type BikeTypeOption = (typeof BIKE_TYPE_OPTIONS)[number];
+
+export const BIKE_STATE_OPTIONS = ["Free", "Rented"] as const;
+export type BikeStateOption = (typeof BIKE_STATE_OPTIONS)[number];
+
 export interface Bike {
   id: string;
   brand: string;
   type: string;
   colour: string;
+  latitude?: number;
+  longitude?: number;
   state?: string;
 }
 

--- a/frontend/src/features/Map/components/BikeMarker.tsx
+++ b/frontend/src/features/Map/components/BikeMarker.tsx
@@ -8,12 +8,7 @@ export default function BikeMarker({ bike }: BikeMarkerProps) {
         <div>
           <p className="font-semibold">Bike</p>
           <p className="font-semibold text-small">ID: {bike.bikeId}</p>
-          <div className="flex gap-2 justify-between items-center">
-            <p className="text-sm text-green-600">Available</p>
-            <button className="px-3 py-1 bg-brand-500 text-white rounded hover:bg-brand-600 max-h-8">
-              Rent
-            </button>
-          </div>
+          <p className="text-sm text-green-600 mt-1">Available</p>
         </div>
       </Popup>
     </Marker>

--- a/frontend/src/services/AuthProvider.tsx
+++ b/frontend/src/services/AuthProvider.tsx
@@ -22,8 +22,23 @@ function computeIsAdmin(token: string | null): boolean {
   return payload.role === "admin";
 }
 
+/** Restore session user from JWT so queries work after full page reload. */
+function userFromStoredToken(token: string | null): AuthUser | null {
+  if (!token) return null;
+  const payload = decodeJwtPayload(token);
+  const uid = payload.sub;
+  if (typeof uid !== "string" || !uid) return null;
+  const email = payload.email;
+  return {
+    uid,
+    email: typeof email === "string" ? email : "",
+  };
+}
+
 export function AuthProvider({ children }: AuthProviderProps) {
-  const [user, setUser] = useState<AuthUser | null>(null);
+  const [user, setUser] = useState<AuthUser | null>(() =>
+    userFromStoredToken(localStorage.getItem("bns_id_token")),
+  );
   const [idToken, setIdToken] = useState<string | null>(() =>
     localStorage.getItem("bns_id_token"),
   );


### PR DESCRIPTION
## Changes

### Map / `BikeMarker`
- Removed the non-functional **Rent** button from the `/map` marker popup.

### Bikes / form
- Added **`BikeLocationPicker`**: Leaflet map to set coordinates via click/drag; default center when no data (Medellín).
- **`BikeForm`**: lat/lng via picker; **Type** and **Status** as `<select>`s matching API enums; payload always sends **state**.
- **Types:** `BIKE_TYPE_OPTIONS` / `BIKE_STATE_OPTIONS`; optional `latitude` / `longitude` on `Bike`.

### Rentals / auth (refresh fix)
- **Issue:** On full reload, `idToken` was restored from `localStorage` but `user` stayed `null` until the next login. `useFetchUserRentals` uses `enabled: !!user`, so the list did not load after F5.
- **Fix:** Hydrate `user` from the stored JWT at startup (same source as the token), so rentals fetch runs after refresh without re-login.